### PR TITLE
feat: add delete method on client service.

### DIFF
--- a/mobile/lib/client/pages/client.page.dart
+++ b/mobile/lib/client/pages/client.page.dart
@@ -88,12 +88,32 @@ class _ClientPageState extends State<ClientPage> {
         _client.firstName = _firstNameController.text;
         _client.lastName = _lastNameController.text;
         _client.cpf = _cpfController.text;
-        _client = await _clientService.save(_client);
-      } finally {
-        LoadingService.hide(context);
+        _client = await _clientService.create(_client, context);
+        _redirectList();
+      } catch(e) {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text("Cliente"),
+              content: const Text("Ops, houve um erro. Tente novamente mais tarde."),
+              actions: [
+                TextButton(
+                  child: const Text("OK"),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                ),
+              ],
+            );
+          },
+        );
       }
+      // } finally {
+      //   // LoadingService.hide(context);
+      // }1
 
-      _redirectList();
+      //
     } else {
       _handleError();
     }

--- a/mobile/lib/client/pages/clients.page.dart
+++ b/mobile/lib/client/pages/clients.page.dart
@@ -6,6 +6,7 @@ import 'package:das_angular_mobile/common/widgets/page-title.widget.dart';
 import 'package:das_angular_mobile/menu/menu.component.dart';
 import 'package:das_angular_mobile/routes/app_routes.dart';
 import 'package:flutter/material.dart';
+import '../../common/services/loading.service.dart';
 
 class ClientsPage extends StatefulWidget {
   const ClientsPage({Key? key}) : super(key: key);
@@ -57,12 +58,65 @@ class _ClientsPageState extends State<ClientsPage> {
                   'CPF': client.cpf.toString(),
                 },
                 onEdit: () {},
-                onDelete: () {},
+                onDelete: () {
+                  _confirmDelete(client);
+                },
               );
             }
           ),
         ),
       ]),
     );
+  }
+
+  _confirmDelete(Client cleint) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Cliente"),
+          content: const Text("Deseja realmente excluir o cliente?"),
+          actions: [
+            TextButton(
+              child: const Text("Sim"),
+              onPressed: () {
+                Navigator.pop(context);
+                _delete(cleint);
+              },
+            ),
+            TextButton(
+              child: const Text("Não"),
+              onPressed: () {
+                Navigator.pop(context);
+              },
+            )
+          ],
+        );
+      },
+    );
+  }
+
+  _delete(Client client) async {
+    try {
+      await clientService.delete(client.id!, context);
+    } catch(e) {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('Cliente'),
+            content: const Text('O cliente possui pedidos, remova-os antes de excluí-lo.'),
+            actions: [
+              TextButton(
+                  child: const Text("OK"),
+                  onPressed: () {
+                    Navigator.popUntil(
+                        context, ModalRoute.withName(AppRoutes.CLIENT));
+                  })
+            ],
+          );
+      });
+    }
+    _findAll();
   }
 }

--- a/mobile/lib/client/services/client.services.dart
+++ b/mobile/lib/client/services/client.services.dart
@@ -50,4 +50,14 @@ class ClientService {
       throw Exception('Error code: ${response.statusCode}');
     }
   }
+
+  Future<void> delete(int id) async {
+    http.Response response = await http.delete(
+      Uri.https(Environment.API_URL, '$CLIENT_URL/$id'),
+      headers: Environment.HEADERS,
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Error code: ${response.statusCode}');
+    }
+  }
 }

--- a/mobile/lib/client/services/client.services.dart
+++ b/mobile/lib/client/services/client.services.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 
 import 'package:das_angular_mobile/client/client.model.dart';
 import 'package:das_angular_mobile/common/environment.dart';
+import '../../common/services/loading.service.dart';
+
+import 'package:flutter/material.dart';
 
 import 'package:http/http.dart' as http;
 
@@ -20,18 +23,20 @@ class ClientService {
     }
   }
 
-  Future<Client> save(Client client) async {
+  Future<Client> save(Client client, BuildContext context) async {
     if (client.id != null) {
       return update(client);
     }
-    return create(client);
+    return create(client, context);
   }
 
-  Future<Client> create(Client client) async {
+  Future<Client> create(Client client, BuildContext context) async {
+    LoadingService.show(context);
     http.Response response = await http.post(
         Uri.http(Environment.API_URL, CLIENT_URL),
         headers: Environment.HEADERS,
         body: client.toJson());
+    LoadingService.hide(context);
     if (response.statusCode == 201) {
       return Client.fromJson(utf8.decode(response.bodyBytes));
     } else {
@@ -51,11 +56,13 @@ class ClientService {
     }
   }
 
-  Future<void> delete(int id) async {
+  Future<void> delete(int id, BuildContext context) async {
+    LoadingService.show(context);
     http.Response response = await http.delete(
       Uri.https(Environment.API_URL, '$CLIENT_URL/$id'),
       headers: Environment.HEADERS,
     );
+    LoadingService.hide(context);
     if (response.statusCode != 200) {
       throw Exception('Error code: ${response.statusCode}');
     }


### PR DESCRIPTION
# Changelog
  - Move context inside client service to handle request errors without infinite loop load.
  - Add delete client.

Co-authored-by: André Gonçalves da Silva <andre.godasi@gmail.com>